### PR TITLE
글쓰기 취소 모달 ui 제작

### DIFF
--- a/components/modal/alert/button.tsx
+++ b/components/modal/alert/button.tsx
@@ -9,8 +9,10 @@ export default function AlertModalButton({
   alertType,
   onClose,
 }: AlertModalButtonProps) {
-  let style: string = "";
-  let text: string = "";
+  let filledStyle: string = "";
+  let ghostStyle: string = "";
+  let filledText: string = "";
+  let ghostText: string = "";
 
   if (
     alertType === "emailNotFound" ||
@@ -18,14 +20,34 @@ export default function AlertModalButton({
     alertType === "signupSuccess" ||
     alertType === "emailInUse"
   ) {
-    style =
-      "flex items-center self-stretch justify-center w-full gap-4 px-16 py-10 h-52 mobile:h-44 min-w-320 rounded-32 bg-primary text-white text-center font-NanumSquareRound text-16 font-extrabold leading-22";
-    text = "확인";
+    filledStyle =
+      "flex items-center self-stretch justify-center w-full gap-4 px-16 py-10 h-52 mobile:h-44 min-w-320 rounded-32 bg-primary text-white text-center font-NanumSquareRound text-18 mobile:text-16 font-extrabold leading-22";
+    filledText = "확인";
+  } else if (alertType === "writingCancel") {
+    filledStyle =
+      "flex h-52 w-full px-16 py-10 justify-center bg-primary items-center gap-4 rounded-32 text-primary text-center font-NanumSquareRound text-white text-18 mobile:text-16 font-extrabold leading-22";
+    ghostStyle =
+      "flex h-52 w-full px-16 py-10 justify-center items-center gap-4 rounded-32 border-[1.5px] border-primary text-primary text-center font-NanumSquareRound text-18 mobile:text-16 font-extrabold leading-22";
+    filledText = "예";
+    ghostText = "아니오";
   }
 
   return (
-    <button className={style} onClick={onClose}>
-      {text}
-    </button>
+    <>
+      {ghostStyle && ghostText ? (
+        <div className="flex items-start self-stretch justify-center gap-12">
+          <button className={ghostStyle} onClick={onClose}>
+            {ghostText}
+          </button>
+          <button className={filledStyle} onClick={onClose}>
+            {filledText}
+          </button>
+        </div>
+      ) : (
+        <button className={filledStyle} onClick={onClose}>
+          {filledText}
+        </button>
+      )}
+    </>
   );
 }

--- a/components/modal/alert/index.tsx
+++ b/components/modal/alert/index.tsx
@@ -1,10 +1,13 @@
+import { ReactNode } from "react";
+
 import AlertModalLayout from "@/components/modal/alert/layout";
 
 export type AlertType =
   | "emailNotFound"
   | "passwordMismatch"
   | "signupSuccess"
-  | "emailInUse";
+  | "emailInUse"
+  | "writingCancel";
 
 interface AlertModalProps {
   alertType: AlertType;
@@ -13,7 +16,7 @@ interface AlertModalProps {
 
 export default function AlertModal({ alertType, onClose }: AlertModalProps) {
   let title: string = "";
-  let message: string = "";
+  let message: string | ReactNode = "";
 
   switch (alertType) {
     case "emailNotFound":
@@ -31,6 +34,16 @@ export default function AlertModal({ alertType, onClose }: AlertModalProps) {
     case "emailInUse":
       title = "";
       message = "이미 사용중인 이메일입니다.";
+      break;
+    case "writingCancel":
+      title = "글쓰기 취소";
+      message = (
+        <>
+          글쓰기를 취소하시겠습니까?
+          <br />
+          작성 중인 내용은 저장되지 않습니다.
+        </>
+      );
       break;
     default:
       break;

--- a/components/modal/alert/layout.tsx
+++ b/components/modal/alert/layout.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { AlertType } from "@/components/modal/alert";
 import AlertModalButton from "@/components/modal/alert/button";
 
 interface AlertModalLayoutProps {
-  alertMessage: string;
+  alertMessage: string | ReactNode;
   alertTitle: string;
   alertType: AlertType;
   onClose: () => void;
@@ -18,10 +18,6 @@ export default function AlertModalLayout({
   onClose,
 }: AlertModalLayoutProps) {
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
-
-  const stopEventBubbling = (e: React.MouseEvent) => {
-    e.stopPropagation();
-  };
 
   useEffect(() => {
     const body = document.body;
@@ -38,10 +34,7 @@ export default function AlertModalLayout({
     portalRoot &&
     createPortal(
       <div className="fixed inset-0 flex items-center justify-center w-full h-full bg-dim-60">
-        <div
-          className="flex flex-col items-center gap-32 px-40 py-48 overflow-x-hidden bg-white shadow-md mobile:gap-24 w-360 mobile:w-288 rounded-32 moblie:px-24 mobile:py-32"
-          onClick={stopEventBubbling}
-        >
+        <div className="flex flex-col items-center gap-32 px-40 py-48 overflow-x-hidden bg-white shadow-md mobile:gap-24 w-360 mobile:w-288 rounded-32 moblie:px-24 mobile:py-32">
           <span className="font-bold text-center text-text-01 leading-32 text-20 mobile:text-18 font-NanumSquareRound">
             {alertTitle}
           </span>

--- a/components/modal/alert/layout.tsx
+++ b/components/modal/alert/layout.tsx
@@ -33,7 +33,7 @@ export default function AlertModalLayout({
   return (
     portalRoot &&
     createPortal(
-      <div className="fixed inset-0 flex items-center justify-center w-full h-full bg-dim-60">
+      <div className="fixed inset-0 z-30 flex items-center justify-center w-full h-full bg-dim-60">
         <div className="flex flex-col items-center gap-32 px-40 py-48 overflow-x-hidden bg-white shadow-md mobile:gap-24 w-360 mobile:w-288 rounded-32 moblie:px-24 mobile:py-32">
           <span className="font-bold text-center text-text-01 leading-32 text-20 mobile:text-18 font-NanumSquareRound">
             {alertTitle}


### PR DESCRIPTION
# 왜 필요한가요?
- 관련 이슈: 글쓰기 취소 모달 ui 제작


# 어떤 변화가 생겼나요?
- 글쓰기 취소 모달 ui 제작 (반응형이 피그마에 없어서 pc 버전만 올립니다. 추후에 업데이트 되면 수정하겠습니다.)
- 두 가지 종류로 나누어 모달의 타입에 따라 보이도록 로직을 수정했습니다. 
- 모달이 최상단에 뜨도록 코드를 수정했습니다. 


# 스크린샷(optional)
![image](https://github.com/GilDongMu/gildongmu/assets/139199039/0e84111c-f4d2-422c-af79-157cf13b987c)
-> filledStyle filledText

![image](https://github.com/GilDongMu/gildongmu/assets/139199039/778fa037-87f3-4d88-a617-be7a8722e169)
-> ghostStyle ghostText / filledStyle filledText

![스크린샷 2024-03-11 161102](https://github.com/GilDongMu/gildongmu/assets/139199039/c399389a-977f-4aa5-9056-ffb0a0c31423)
![스크린샷 2024-03-11 161122](https://github.com/GilDongMu/gildongmu/assets/139199039/8021d7b0-859e-42d6-81cb-0c1c640fe4f0)
