### PR TITLE
캘린더 데이터 수정 및 mobile 인풋 텍스트 사이즈 수정

### DIFF
--- a/components/form/input/ContentInput.tsx
+++ b/components/form/input/ContentInput.tsx
@@ -6,10 +6,12 @@ function ContentTextarea({
   onChange,
   value,
   isError,
+  id,
 }: {
   onChange: (value: string) => void;
   value: string;
   isError?: boolean;
+  id: string;
 }) {
   const [text, setText] = useState(value);
 
@@ -22,12 +24,12 @@ function ContentTextarea({
   }, [text, onChange]);
 
   return (
-    <div className="w-[756px] tablet:w-[672px] mobile:w-272 flex flex-col gap-4">
+    <div className="flex w-[756px] flex-col gap-4 tablet:w-[672px] mobile:w-272">
       <Textarea
-        id="content"
+        id={id}
         value={text}
-        onChange={(e) => setText(e.target.value)}
-        className={`w-full h-[211px] bg-bg-02 resize-none placeholder:text-text-05 tablet:h-[214px] border border-line-02 rounded-12 px-16 py-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01 ${isError && "bg-input-error border-0"}`}
+        onChange={e => setText(e.target.value)}
+        className={`h-[211px] w-full resize-none rounded-12 border border-line-02 bg-bg-02 px-16 py-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:h-[214px] mobile:text-sm ${isError && "border-0 bg-input-error"}`}
         placeholder="모집 내용을 작성해 주세요"
       />
     </div>

--- a/components/form/input/CounterInput.tsx
+++ b/components/form/input/CounterInput.tsx
@@ -6,9 +6,11 @@ import { Input } from "@/components/ui/input";
 function CounterInput({
   onChange,
   isError,
+  id,
 }: {
   onChange: (value: number) => void;
   isError: boolean;
+  id: string;
 }) {
   const [count, setCount] = useState(0);
 
@@ -43,22 +45,23 @@ function CounterInput({
     <div className="flex items-center gap-12">
       <Button
         type="button"
-        variant={count <= 0?"ghost":"outline"}
-        className="w-44 h-44 rounded-ful border-2 tablet:w-36 tablet:h-36"
+        variant={count <= 0 ? "ghost" : "outline"}
+        className="rounded-ful h-44 w-44 border-2 tablet:h-36 tablet:w-36"
         onClick={handleDecrement}
       >
         -
       </Button>
       <Input
+        id={id}
         type="text"
         value={count}
         onChange={handleChange}
-        className={`w-254 h-52 px-16 text-center text-l rounded-xl focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-228 mobile:w-176 ${isError && "bg-input-error border-0"}`}
+        className={`text-l h-52 w-254 rounded-xl px-16 text-center focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-228 mobile:w-176 mobile:text-sm ${isError && "border-0 bg-input-error"}`}
       />
       <Button
         type="button"
         variant={count >= 99 ? "ghost" : "outline"}
-        className="w-44 h-44 rounded-full border-2 tablet:w-36 tablet:h-36"
+        className="h-44 w-44 rounded-full border-2 tablet:h-36 tablet:w-36"
         onClick={handleIncrement}
       >
         +

--- a/components/form/input/DatePickerInput.tsx
+++ b/components/form/input/DatePickerInput.tsx
@@ -7,7 +7,7 @@ import { DayPicker } from "react-day-picker";
 
 import { Input } from "@/components/ui/input";
 
-function DatePickerInput({ onChange, value }: any) {
+function DatePickerInput({ onChange, value, id }: any) {
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const formattedDate = value
     ? format(value, "yyyy년 MM월 dd일", { locale: ko })
@@ -18,7 +18,11 @@ function DatePickerInput({ onChange, value }: any) {
   };
 
   const handleDaySelect = (day: Date | undefined) => {
-    onChange(day);
+    if (day) {
+      onChange(format(day, "yyyy-MM-dd"));
+    } else {
+      console.error("날짜 데이터 전송 오류");
+    }
     setIsPickerOpen(false);
   };
 
@@ -33,11 +37,12 @@ function DatePickerInput({ onChange, value }: any) {
     <>
       <div className="relative">
         <Input
+          id={id}
           value={formattedDate}
           readOnly
           onClick={handleInputClick}
           placeholder="생년월일 입력"
-          className="w-[756px] h-52 bg-bg-02 placeholder:text-text-05 tablet:w-[672px] mobile:w-272 border border-line-02 rounded-12 px-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01"
+          className="h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
         />
         {isPickerOpen && (
           <div className="absolute top-full z-10 bg-white">

--- a/components/form/input/ImageUploadInput.tsx
+++ b/components/form/input/ImageUploadInput.tsx
@@ -29,10 +29,10 @@ function ImageUpload({
   const triggerFileInput = () => document.getElementById("fileInput")?.click();
 
   return (
-    <div className="flex justify-center items-center">
+    <div className="flex items-center justify-center">
       <div className="relative">
         <input id="fileInput" type="file" hidden onChange={handleFileChange} />
-        <div className="w-120 h-120 rounded-full overflow-hidden mt-4 border-4 border-line-02 relative tablet:w-90 tablet:h-90">
+        <div className="relative mt-4 h-120 w-120 overflow-hidden rounded-full border-4 border-line-02 tablet:h-90 tablet:w-90">
           <Image
             src={imageSrc || "/icons/defaultProfile.png"}
             alt="Profile"
@@ -42,7 +42,7 @@ function ImageUpload({
         </div>
         <button
           type="button"
-          className="w-32 h-32 absolute right-0 bottom-0"
+          className="absolute bottom-0 right-0 h-32 w-32"
           onClick={triggerFileInput}
         >
           <Image

--- a/components/form/input/IntroTextarea.tsx
+++ b/components/form/input/IntroTextarea.tsx
@@ -5,9 +5,11 @@ import { Textarea } from "@/components/ui/textarea";
 function IntroTextarea({
   onChange,
   value,
+  id,
 }: {
   onChange: (value: string) => void;
   value: string;
+  id: string;
 }) {
   const [text, setText] = useState(value);
 
@@ -24,15 +26,15 @@ function IntroTextarea({
   };
 
   return (
-    <div className="w-[756px] tablet:w-[672px] mobile:w-272 flex flex-col gap-4">
+    <div className="flex w-[756px] flex-col gap-4 tablet:w-[672px] mobile:w-272">
       <Textarea
-        id="bio"
+        id={id}
         value={text}
         onChange={handleChange}
-        className="w-full h-137 bg-bg-02 resize-none placeholder:text-text-05 tablet:w-[672px] mobile:w-272 border border-line-02 rounded-12 px-16 py-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01"
+        className="h-137 w-full resize-none rounded-12 border border-line-02 bg-bg-02 px-16 py-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
         placeholder="자기소개를 입력해 주세요"
       />
-      <p className="text-sm text-gray-500 mt-1 self-end">
+      <p className="mt-1 self-end text-sm text-gray-500">
         {text?.length ?? 0} / 200
       </p>
     </div>

--- a/components/form/input/MultipleImageUploadInput.tsx
+++ b/components/form/input/MultipleImageUploadInput.tsx
@@ -6,7 +6,11 @@ interface ImagePreview {
   preview: string;
 }
 
-function MultipleImageUploadInput({ onChange }: { onChange: (images: ImagePreview[]) => void }) {
+function MultipleImageUploadInput({
+  onChange,
+}: {
+  onChange: (images: ImagePreview[]) => void;
+}) {
   const [imagesPreview, setImagesPreview] = useState<ImagePreview[]>([]);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -37,16 +41,19 @@ function MultipleImageUploadInput({ onChange }: { onChange: (images: ImagePrevie
     image: ImagePreview;
     index: number;
   }) => (
-    <div key={index} className="w-132 h-132 mr-2 relative group tablet:w-118 tablet:h-118">
+    <div
+      key={index}
+      className="group relative mr-2 h-132 w-132 tablet:h-118 tablet:w-118"
+    >
       <Image
         src={image.preview}
         alt={`preview ${index}`}
         fill
-        className="border border-line-02 rounded-2xl object-cover"
+        className="rounded-2xl border border-line-02 object-cover"
       />
       <button
         onClick={() => handleRemoveImage(index)}
-        className="w-20 h-20 flex items-center justify-center absolute top-5 right-5 bg-primary text-white rounded-xl"
+        className="absolute right-5 top-5 flex h-20 w-20 items-center justify-center rounded-xl bg-primary text-white"
       >
         x
       </button>
@@ -54,7 +61,10 @@ function MultipleImageUploadInput({ onChange }: { onChange: (images: ImagePrevie
   );
 
   const ImageUploadButton = () => (
-    <label htmlFor="file" className="cursor-pointer w-132 bg-bg-02 border border-line-02 rounded-2xl h-132 flex justify-center items-center tablet:w-118 tablet:h-118">
+    <label
+      htmlFor="file"
+      className="flex h-132 w-132 cursor-pointer items-center justify-center rounded-2xl border border-line-02 bg-bg-02 tablet:h-118 tablet:w-118"
+    >
       <input
         type="file"
         id="file"
@@ -72,16 +82,16 @@ function MultipleImageUploadInput({ onChange }: { onChange: (images: ImagePrevie
   );
 
   const TitleBage = () => (
-    <div className="w-42 h-24 flex items-center justify-center rounded-24 bg-tag-orange-100 text-tag-orange-500 text-xs absolute left-8 top-8 mobile:left-10">
+    <div className="absolute left-8 top-8 flex h-24 w-42 items-center justify-center rounded-24 bg-tag-orange-100 text-xs text-tag-orange-500 mobile:left-10">
       대표
     </div>
   );
 
   return (
     <div className="relative">
-      <div className="w-[756px] flex gap-24 tablet:w-[672px] tablet:gap-20 mobile:w-272 mobile:grid mobile:grid-cols-2">
+      <div className="flex w-[756px] gap-24 tablet:w-[672px] tablet:gap-20 mobile:grid mobile:w-272 mobile:grid-cols-2">
         {Array.from({ length: 5 }).map((_, index) => (
-          <div key={index} className="flex justify-center items-center">
+          <div key={index} className="flex items-center justify-center">
             {imagesPreview[index] ? (
               <ImagePreviewComponent
                 image={imagesPreview[index]}

--- a/components/form/input/RadioInput.tsx
+++ b/components/form/input/RadioInput.tsx
@@ -5,43 +5,46 @@ function RadioInput({
   onChange,
   value,
   pageType,
+  id,
 }: {
   onChange: (value: string) => void;
   value: string;
   pageType: string;
+  id: string;
 }) {
   const handleChange = (newValue: string) => {
     onChange(newValue);
   };
   return (
     <RadioGroup
+      id={id}
       defaultValue={value}
       className="flex gap-5"
       onValueChange={handleChange}
     >
       {pageType === "write" && (
-        <div className="w-121 h-24 flex items-center gap-12 mobile:w-100">
+        <div className="flex h-24 w-121 items-center gap-12 mobile:w-100">
           <RadioGroupItem
             value="none"
             id="none"
-            className="w-24 h-24 border-line-01 mobile:w-20 mobile:h-20"
+            className="h-24 w-24 border-line-01 mobile:h-20 mobile:w-20"
           />
           <Label htmlFor="none">상관없음</Label>
         </div>
       )}
-      <div className="w-121 h-24 flex items-center gap-12 mobile:w-80">
+      <div className="flex h-24 w-121 items-center gap-12 mobile:w-80">
         <RadioGroupItem
           value="male"
           id="male"
-          className="w-24 h-24 border-line-01 mobile:w-20 mobile:h-20"
+          className="h-24 w-24 border-line-01 mobile:h-20 mobile:w-20"
         />
         <Label htmlFor="male">{pageType === "write" ? "남자만" : "남자"}</Label>
       </div>
-      <div className="w-121 h-24 flex items-center gap-12 mobile:w-80">
+      <div className="flex h-24 w-121 items-center gap-12 mobile:w-80">
         <RadioGroupItem
           value="female"
           id="female"
-          className="w-24 h-24 border-line-01 mobile:w-20 mobile:h-20"
+          className="h-24 w-24 border-line-01 mobile:h-20 mobile:w-20"
         />
         <Label htmlFor="female">
           {pageType === "write" ? "여자만" : "여자"}

--- a/components/form/input/RangeDatePickerInput.tsx
+++ b/components/form/input/RangeDatePickerInput.tsx
@@ -8,7 +8,7 @@ import { DateRange, DayPicker } from "react-day-picker";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
-function RangeDatePickerInput({ onChange }: any) {
+function RangeDatePickerInput({ onChange, id }: any) {
   const [range, setRange] = useState<DateRange | undefined>();
   const [inputValue, setInputValue] = useState("");
   const [isPickerOpen, setIsPickerOpen] = useState(false);
@@ -24,7 +24,16 @@ function RangeDatePickerInput({ onChange }: any) {
   }, [range]);
 
   const handleSelectButton = () => {
-    onChange(range);
+    if (range?.from && range?.to) {
+      const formattedFrom = format(range.from, "yyyy-MM-dd");
+      const formattedTo = format(range.to, "yyyy-MM-dd");
+      onChange({
+        startDate: formattedFrom,
+        endDate: formattedTo,
+      });
+    } else {
+      console.error("날짜 데이터 전송 오류");
+    }
     setIsPickerOpen(false);
   };
 
@@ -39,13 +48,13 @@ function RangeDatePickerInput({ onChange }: any) {
     <>
       <div className="relative">
         <Input
-          id="date"
+          id={id}
           type="text"
           value={inputValue}
           readOnly
           placeholder="여행 일정을 선택해 주세요"
           onClick={() => setIsPickerOpen(true)}
-          className="w-[756px] h-52 bg-bg-02 placeholder:text-text-05 tablet:w-[672px] mobile:w-272 border border-line-02 rounded-12 px-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01"
+          className="h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
         />
         <style>{css}</style>
         {isPickerOpen && (
@@ -69,7 +78,7 @@ function RangeDatePickerInput({ onChange }: any) {
               />
               <Button
                 onClick={handleSelectButton}
-                className="absolute text-xs w-35 h-25 rounded-15 right-20 -bottom-10"
+                className="absolute -bottom-10 right-20 h-25 w-35 rounded-15 text-xs"
               >
                 선택
               </Button>

--- a/components/form/input/TagInput.tsx
+++ b/components/form/input/TagInput.tsx
@@ -3,7 +3,7 @@ import React, { KeyboardEvent, useEffect, useState } from "react";
 
 import { Input } from "@/components/ui/input";
 
-function TagInput({ onChange, value, formType }: any) {
+function TagInput({ onChange, value, formType, id }: any) {
   const [tags, setTags] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState("");
 
@@ -65,8 +65,8 @@ function TagInput({ onChange, value, formType }: any) {
     <div>
       <Input
         type="text"
-        id="tags"
-        className="w-[756px] h-52 bg-bg-02 mb-5 placeholder:text-text-05 tablet:w-[672px] mobile:w-272 border border-line-02 rounded-12 px-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01"
+        id={id}
+        className="mb-5 h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
         value={inputValue}
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}
@@ -77,7 +77,7 @@ function TagInput({ onChange, value, formType }: any) {
         {tags.map((tag, index) => (
           <span
             key={index}
-            className={`h-34 mobile:h-28 px-13 py-5 bg-primary rounded-24 text-16 mobile:text-14 flex items-center gap-5 ${tagStyles[index]} ${tagTextStyles[index]}`}
+            className={`flex h-34 items-center gap-5 rounded-24 bg-primary px-13 py-5 text-16 mobile:h-28 mobile:text-14 ${tagStyles[index]} ${tagTextStyles[index]}`}
           >
             # {tag}
             <button type="button" onClick={() => removeTag(index)}>

--- a/components/form/signupForm/index.tsx
+++ b/components/form/signupForm/index.tsx
@@ -46,14 +46,14 @@ function SignUpForm() {
   return (
     <>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <div className="bg-white w-[956px] px-32 py-48 flex flex-col rounded-32 items-center tablet:w-[720px] mobile:w-[312px]">
+        <div className="flex w-[956px] flex-col items-center rounded-32 bg-white px-32 py-48 tablet:w-[720px] mobile:w-[312px]">
           <div className="flex flex-col gap-24">
-            <div className="flex items-center mb-20">
-              <div className="w-294 h-px bg-line-02 tablet:w-248 mobile:w-52"></div>
+            <div className="mb-20 flex items-center">
+              <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
               <div className="text-18 tablet:text-16 mobile:text-14">
                 필수 정보 입력
               </div>
-              <div className="w-294 h-px bg-line-02 tablet:w-248 mobile:w-52"></div>
+              <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
             </div>
             <div className="flex flex-col gap-8">
               <Label htmlFor="email">
@@ -62,17 +62,17 @@ function SignUpForm() {
               <Input
                 id="email"
                 type="email"
-                className={`w-[756px] h-52 bg-bg-02 placeholder:text-text-05 tablet:w-[672px] mobile:w-272 border border-line-02 rounded-12 px-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01 ${errors.email && "bg-input-error border-0"}`}
+                className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 text-base placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.email && "border-0 bg-input-error"}`}
                 placeholder="이메일을 입력해 주세요"
                 {...register("email", { required: true, pattern: regEmail })}
               />
               {errors.email && errors.email.type === "required" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   이메일을 입력해 주세요
                 </span>
               )}
               {errors.email && errors.email.type === "pattern" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   이메일 형식으로 작성해 주세요
                 </span>
               )}
@@ -84,7 +84,7 @@ function SignUpForm() {
               <Input
                 id="nickname"
                 type="text"
-                className={`w-[756px] h-52 bg-bg-02 placeholder:text-text-05 tablet:w-[672px] mobile:w-272 border border-line-02 rounded-12 px-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01 ${errors.nickname && "bg-input-error border-0"}`}
+                className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.nickname && "border-0 bg-input-error"}`}
                 placeholder="닉네임을 입력해 주세요"
                 {...register("nickname", {
                   required: true,
@@ -93,17 +93,17 @@ function SignUpForm() {
                 })}
               />
               {errors.nickname && errors.nickname.type === "required" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   닉네임을 입력해 주세요
                 </span>
               )}
               {errors.nickname && errors.nickname.type === "minLength" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   닉네임은 최소 2글자 입니다
                 </span>
               )}
               {errors.nickname && errors.nickname.type === "maxLength" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   닉네임은 최대 8글자 입니다
                 </span>
               )}
@@ -116,18 +116,18 @@ function SignUpForm() {
                 <Input
                   id="password"
                   type={passwordShown ? "text" : "password"}
-                  className={`w-[756px] h-52 bg-bg-02 placeholder:text-text-05 tablet:w-[672px] mobile:w-272 border border-line-02 rounded-12 px-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01 ${errors.password && "bg-input-error text-text-02 border-0"}`}
+                  className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.password && "border-0 bg-input-error text-text-02"}`}
                   placeholder="비밀번호를 입력해 주세요"
                   {...register("password", {
                     required: true,
                     pattern: regPassword,
                   })}
                 />
-                <div className="absolute inset-y-0 right-0 flex items-center justify-center px-16 h-full">
+                <div className="absolute inset-y-0 right-0 flex h-full items-center justify-center px-16">
                   <button
                     type="button"
                     onClick={togglePasswordVisiblity}
-                    className="w-24 h-24 relative"
+                    className="relative h-24 w-24"
                   >
                     <Image
                       src={`/icons/eye-${passwordShown ? "off" : "on"}.png`}
@@ -138,12 +138,12 @@ function SignUpForm() {
                 </div>
               </div>
               {errors.password && errors.password.type === "required" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   비밀번호를 입력해 주세요
                 </span>
               )}
               {errors.password && errors.password.type === "pattern" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   영어, 숫자, 특수문자를 조합하여 8자리 이상 입력해 주세요
                 </span>
               )}
@@ -156,18 +156,18 @@ function SignUpForm() {
                 <Input
                   id="confimPassword"
                   type={confirmPasswordShown ? "text" : "password"}
-                  className={`w-[756px] h-52 bg-bg-02 placeholder:text-text-05 tablet:w-[672px] mobile:w-272 border border-line-02 rounded-12 px-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01 ${errors.confirmPassword && "bg-input-error border-0"}`}
+                  className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.confirmPassword && "border-0 bg-input-error"}`}
                   placeholder="비밀번호를 다시 입력해 주세요"
                   {...register("confirmPassword", {
                     required: true,
                     validate: value => value === password,
                   })}
                 />
-                <div className="absolute inset-y-0 right-0 flex items-center justify-center px-16 h-full">
+                <div className="absolute inset-y-0 right-0 flex h-full items-center justify-center px-16">
                   <button
                     type="button"
                     onClick={toggleConfirmPasswordVisibility}
-                    className="w-24 h-24 relative"
+                    className="relative h-24 w-24"
                   >
                     <Image
                       src={`/icons/eye-${confirmPasswordShown ? "off" : "on"}.png`}
@@ -178,7 +178,7 @@ function SignUpForm() {
                 </div>
               </div>
               {errors.confirmPassword && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   비밀번호가 일치하지 않습니다
                 </span>
               )}
@@ -196,35 +196,37 @@ function SignUpForm() {
                     onChange={(gender: any) => field.onChange(gender)}
                     value={field.value}
                     pageType="singUp"
+                    id={"gender"}
                   />
                 )}
               />
             </div>
             <div className="flex flex-col gap-8">
-              <Label htmlFor="birthDate">
+              <Label htmlFor="date">
                 생년월일<span className="text-pink-500">*</span>
               </Label>
               <Controller
                 control={control}
-                name="birthDate"
+                name="dayOfBirth"
                 rules={{ required: true }}
                 render={({ field }) => (
                   <DatePickerInput
                     onChange={(date: any) => field.onChange(date)}
                     value={field.value}
+                    id={"date"}
                   />
                 )}
               />
             </div>
           </div>
-          <div className="flex items-center my-40 gap-32 tablet:gap-28">
-            <div className="w-294 h-px bg-line-02 tablet:w-248 mobile:w-52"></div>
+          <div className="my-40 flex items-center gap-32 tablet:gap-28">
+            <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
             <div className="text-18 tablet:text-16 mobile:text-14">
               추가 정보 입력
             </div>
-            <div className="w-294 h-px bg-line-02 tablet:w-248 mobile:w-52"></div>
+            <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
           </div>
-          <div className="flex flex-col gap-24 items-center">
+          <div className="flex flex-col items-center gap-24">
             <Controller
               control={control}
               name="imageUpload"
@@ -239,12 +241,13 @@ function SignUpForm() {
               <Label htmlFor="tags">좋아하는 여행지</Label>
               <Controller
                 control={control}
-                name="tags"
+                name="favoriteSpots"
                 render={({ field }) => (
                   <TagInput
                     onChange={(tags: any) => field.onChange(tags)}
                     value={field.value}
                     formType={"signUp"}
+                    id={"tags"}
                   />
                 )}
               />
@@ -258,17 +261,18 @@ function SignUpForm() {
                   <IntroTextarea
                     onChange={text => field.onChange(text)}
                     value={field.value}
+                    id={"bio"}
                   />
                 )}
               />
             </div>
           </div>
         </div>
-        <div className="w-[956px] mt-40 flex flex-col rounded-32 items-center tablet:w-[720px] mobile:w-[312px]">
+        <div className="mt-40 flex w-[956px] flex-col items-center rounded-32 tablet:w-[720px] mobile:w-[312px]">
           <button
             type="submit"
             disabled={!isValid}
-            className="w-240 h-52 bg-primary hover:bg-primary-press text-white rounded-32 flex justify-center items-center disabled:bg-line-02 disabled:text-text-04 mobile:w-180 mobile:h-44"
+            className="flex h-52 w-240 items-center justify-center rounded-32 bg-primary text-white hover:bg-primary-press disabled:bg-line-02 disabled:text-text-04 mobile:h-44 mobile:w-180"
           >
             가입하기
           </button>

--- a/components/form/signupForm/index.tsx
+++ b/components/form/signupForm/index.tsx
@@ -47,14 +47,14 @@ function SignUpForm() {
     <>
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className="flex w-[956px] flex-col items-center rounded-32 bg-white px-32 py-48 tablet:w-[720px] mobile:w-[312px]">
-          <div className="flex flex-col gap-24">
-            <div className="mb-20 flex items-center">
-              <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
-              <div className="text-18 tablet:text-16 mobile:text-14">
-                필수 정보 입력
-              </div>
-              <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
+          <div className="mb-40 flex items-center gap-32 tablet:gap-28">
+            <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
+            <div className="text-18 tablet:text-16 mobile:text-14">
+              필수 정보 입력
             </div>
+            <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
+          </div>
+          <div className="flex flex-col gap-24">
             <div className="flex flex-col gap-8">
               <Label htmlFor="email">
                 이메일<span className="text-pink-500">*</span>

--- a/components/form/writeForm/index.tsx
+++ b/components/form/writeForm/index.tsx
@@ -18,9 +18,8 @@ function WriteForm() {
     handleSubmit,
     control,
     formState: { errors, isValid },
-    watch,
   } = useForm({ mode: "onBlur" });
-  
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
 
@@ -37,17 +36,17 @@ function WriteForm() {
   return (
     <>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <div className="bg-white w-[956px] px-32 py-48 flex flex-col rounded-32 items-center tablet:w-[720px] mobile:w-[312px]">
+        <div className="flex w-[956px] flex-col items-center rounded-32 bg-white px-32 py-48 tablet:w-[720px] mobile:w-[312px]">
           <div className="flex flex-col gap-32">
-            <div className="flex flex-col items-center mb-8">
+            <div className="mb-8 flex flex-col items-center">
               <Input
                 type="text"
-                className={`w-[756px] h-52 text-xl text-center font-bold border-0 border-b rounded-0 px-24 pt-12 pb-24 placeholder:text-text-05 tablet:w-[672px] mobile:w-272 focus-visible:ring-0 focus-visible:ring-offset-0 ${errors.email && "bg-input-error"}`}
+                className={`h-52 w-[756px] rounded-0 border-0 border-b px-24 pb-24 pt-12 text-center text-xl font-bold placeholder:text-text-05 focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 ${errors.email && "bg-input-error"}`}
                 placeholder="제목을 입력해 주세요"
                 {...register("title", { required: true })}
               />
               {errors.title && errors.title.type === "required" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   제목을 입력해 주세요
                 </span>
               )}
@@ -58,9 +57,9 @@ function WriteForm() {
               </Label>
               <Input
                 placeholder="여행지 입력"
-                className="w-[756px] h-52 bg-bg-02 placeholder:text-text-05 tablet:w-[672px] mobile:w-272 border border-line-02 rounded-12 px-16 focus-visible:ring-0 focus-visible:ring-offset-0 focus:bg-white focus:border focus:border-line-01"
+                className="h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272"
               />
-              <div className="w-[756px] h-[240px] bg-line-02 tablet:w-[672px] mobile:w-272">
+              <div className="h-[240px] w-[756px] bg-line-02 tablet:w-[672px] mobile:w-272">
                 지도
               </div>
             </div>
@@ -76,11 +75,12 @@ function WriteForm() {
                   <RangeDatePickerInput
                     onChange={(date: any) => field.onChange(date)}
                     value={field.value}
+                    id={"date"}
                   />
                 )}
               />
               {errors.tripDate && errors.tripDate.type === "required" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   여행 일정을 선택해 주세요
                 </span>
               )}
@@ -91,7 +91,7 @@ function WriteForm() {
               </Label>
               <Controller
                 control={control}
-                name="member"
+                name="numberOfPeople"
                 rules={{
                   required: "모집 인원을 입력해 주세요",
                   validate: value =>
@@ -102,9 +102,10 @@ function WriteForm() {
                     <CounterInput
                       onChange={(member: number) => field.onChange(member)}
                       isError={!!error}
+                      id={"member"}
                     />
                     {error && (
-                      <span className="text-system-error text-12">
+                      <span className="text-12 text-system-error">
                         {error.message}
                       </span>
                     )}
@@ -125,17 +126,18 @@ function WriteForm() {
                     onChange={(gender: any) => field.onChange(gender)}
                     value={field.value}
                     pageType="write"
+                    id={"gender"}
                   />
                 )}
               />
               {errors.gender && errors.gender.type === "required" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   성별 구성을 선택해 주세요
                 </span>
               )}
             </div>
             <div className="flex flex-col gap-8">
-              <Label>
+              <Label htmlFor="content">
                 모집 내용<span className="text-pink-500">*</span>
               </Label>
               <Controller
@@ -147,11 +149,12 @@ function WriteForm() {
                     onChange={content => field.onChange(content)}
                     value={field.value}
                     isError={!!fieldState.error}
+                    id={"content"}
                   />
                 )}
               />
               {errors.content && errors.content.type === "required" && (
-                <span className="text-system-error text-12">
+                <span className="text-12 text-system-error">
                   모집 내용을 작성해 주세요
                 </span>
               )}
@@ -160,7 +163,7 @@ function WriteForm() {
               <Label>이미지</Label>
               <Controller
                 control={control}
-                name="imageUpload"
+                name="images"
                 render={({ field }) => (
                   <MultipleImageUploadInput
                     onChange={imagesUrl => field.onChange(imagesUrl)}
@@ -178,25 +181,26 @@ function WriteForm() {
                     onChange={(tags: any) => field.onChange(tags)}
                     value={field.value}
                     formType={"write"}
+                    id={"tags"}
                   />
                 )}
               />
             </div>
           </div>
         </div>
-        <div className="w-[956px] mt-40 flex gap-20 items-center justify-center tablet:w-[720px] tablet:mt-32 mobile:w-[312px]">
+        <div className="mt-40 flex w-[956px] items-center justify-center gap-20 tablet:mt-32 tablet:w-[720px] mobile:w-[312px]">
           <Button
             variant={"outline"}
             type="button"
             onClick={handleWritingCancel}
-            className="w-180 h-52 tablet:w-128 tablet:h-44"
+            className="h-52 w-180 tablet:h-44 tablet:w-128"
           >
             취소
           </Button>
           <Button
             type="submit"
             disabled={!isValid}
-            className="w-180 h-52 tablet:w-128 tablet:h-44"
+            className="h-52 w-180 tablet:h-44 tablet:w-128"
           >
             작성하기
           </Button>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "**/*.ts",
     "**/*.tsx",
     "store/gnb.js",
-    "lib/api/axios.js"
+    "lib/api/axios.js",
+    "lib/utils/regexp.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# 왜 필요한가요?

- 관련 이슈: 캘린더 데이터 수정 및 mobile 인풋 텍스트 사이즈 수정

# 어떤 변화가 생겼나요?

- 모바일 사이즈일 때 인풋 텍스트 사이즈가 14px로 수정됐습니다.
- shadcn/ui의 input, textarea의 기본 텍스트 사이즈가 text-sm(14px)에서 text-base(16px)로 수정됐습니다.
- 회원가입 페이지, 글쓰기 페이지에서의 날짜 데이터 형식이 수정됐습니다.
- 회원가입 페이지에 '필수 정보 입력' 타이틀이 수정됐습니다.

# 추가 사항

- 프로젝트 이슈 번호 #68 인데 브랜치에서 67번으로 잘못 올렸습니다 🥹

# 스크린샷
![스크린샷 2024-03-16 오후 10 51 37](https://github.com/GilDongMu/gildongmu/assets/137983583/89b6eaba-c8bc-49b8-8642-f8ec80527e2f)
### 회원가입 페이지
![스크린샷 2024-03-16 오후 10 53 01](https://github.com/GilDongMu/gildongmu/assets/137983583/9a99f21f-4517-4aca-805c-9412e900a1c2)
### 글쓰기 페이지
![스크린샷 2024-03-16 오후 10 55 52](https://github.com/GilDongMu/gildongmu/assets/137983583/04ee430b-9d90-4b36-8b78-6e75ba2166c9)
