### PR TITLE
상세 페이지 타이틀 분기 모바일 반응형 디자인 추가

### DIFF
--- a/components/detail/title/DetailTitle.tsx
+++ b/components/detail/title/DetailTitle.tsx
@@ -9,7 +9,7 @@ import useToggle from "@/hooks/useToggle";
 function DetailTitle() {
   const router = useRouter();
 
-  const isOwner = true; // 작성자인지 아닌지
+  const isOwner = false; // 작성자인지 아닌지
   const isSubmit = false; // 신청했는지 아닌지
 
   //  데이터 예시
@@ -55,8 +55,8 @@ function DetailTitle() {
 
   return (
     <>
-      <div className="flex h-136 w-[956px] flex-col gap-16 rounded-24 bg-white px-32 py-24 tablet:h-128 tablet:w-[720px] mobile:h-194 mobile:w-[312px] mobile:px-20">
-        <div className="flex items-center justify-between mobile:flex-col mobile:items-start mobile:justify-normal mobile:relative">
+      <div className="mx-auto my-0 flex h-136 w-[956px] flex-col gap-16 rounded-24 bg-white px-32 py-24 tablet:h-128 tablet:w-[720px] mobile:h-194 mobile:w-[312px] mobile:px-20">
+        <div className="flex items-center justify-between mobile:relative mobile:flex-col mobile:items-start mobile:justify-normal">
           <div className="text-20 font-bold tablet:text-18">
             {titleData.title}
           </div>

--- a/components/detail/title/DetailTitle.tsx
+++ b/components/detail/title/DetailTitle.tsx
@@ -9,7 +9,7 @@ import useToggle from "@/hooks/useToggle";
 function DetailTitle() {
   const router = useRouter();
 
-  const isOwner = false; // 작성자인지 아닌지
+  const isOwner = true; // 작성자인지 아닌지
   const isSubmit = false; // 신청했는지 아닌지
 
   //  데이터 예시
@@ -55,14 +55,14 @@ function DetailTitle() {
 
   return (
     <>
-      <div className="flex h-136 w-[956px] flex-col gap-12 rounded-24 bg-white px-32 py-24 tablet:h-128 tablet:w-[720px] mobile:h-194 mobile:w-[312px] mobile:px-20">
-        <div className="flex items-center justify-between">
+      <div className="flex h-136 w-[956px] flex-col gap-16 rounded-24 bg-white px-32 py-24 tablet:h-128 tablet:w-[720px] mobile:h-194 mobile:w-[312px] mobile:px-20">
+        <div className="flex items-center justify-between mobile:flex-col mobile:items-start mobile:justify-normal mobile:relative">
           <div className="text-20 font-bold tablet:text-18">
             {titleData.title}
           </div>
-          <div className="flex gap-16">
+          <div>
             {isOwner ? (
-              <div className="flex h-44 items-center gap-8">
+              <div className="flex h-44 items-center gap-8 mobile:absolute mobile:right-0 mobile:top-110">
                 <button
                   type="button"
                   className="relative h-24 w-24"
@@ -89,7 +89,7 @@ function DetailTitle() {
                 </button>
               </div>
             ) : (
-              <div className="flex gap-16">
+              <div className="flex gap-16 mobile:absolute mobile:right-0 mobile:top-110">
                 <button
                   type="button"
                   className={`relative h-44 w-44 ${isRotating ? "heartRotate" : ""} tablet:h-36 tablet:w-36`}
@@ -117,7 +117,7 @@ function DetailTitle() {
                 ) : (
                   <Button
                     type="button"
-                    className="h-44 w-91 tablet:h-36 tablet:w-83 tablet:text-14"
+                    className="h-44 w-91 tablet:h-36 tablet:w-83 tablet:text-14 mobile:w-220"
                     onClick={handleModal}
                   >
                     신청하기

--- a/pages/travel/[Id]/detail/index.tsx
+++ b/pages/travel/[Id]/detail/index.tsx
@@ -3,11 +3,13 @@ import React from "react";
 
 import Article from "@/components/detail/article";
 import Header from "@/components/detail/header/index";
+import DetailTitle from "@/components/detail/title/DetailTitle";
 
 function Detail() {
   return (
     <div className="w-1200 flex flex-col bg-sky-50">
       <Header />
+      <DetailTitle />
       <Article />
       <div
         className="fixed bottom-40 right-40 h-64 w-64 animate-bounce cursor-pointer"


### PR DESCRIPTION
# 관련사항
 - 상세 페이지 타이틀 분기 모바일 반응형 디자인 추가

# 뭐가 변했나요?
- componets/detail/title 폴더로 파일 이동
- 모바일 반응형 추가

# 특이사항
- 상세보기 페이지에 넣었을 때 ui 위치 수정 필요
- 탭과 모달이 겹치는 오류 발생

# 스크린샷
![스크린샷 2024-03-20 오전 10 56 59](https://github.com/GilDongMu/gildongmu/assets/137983583/3ec8fcef-5426-402d-8b2b-064ab40d28ee)
![스크린샷 2024-03-20 오전 10 57 14](https://github.com/GilDongMu/gildongmu/assets/137983583/03734959-c03b-42a6-8075-71fba4107d61)
