### PR TITLE
상세페이지 디자인 수정 및 그에 필요한 기능 구현

### DIFF
--- a/components/detail/article/contents/comments/index.tsx
+++ b/components/detail/article/contents/comments/index.tsx
@@ -4,11 +4,11 @@ import OthersComment from "@/components/detail/article/contents/comments/others"
 import RegisterComment from "@/components/detail/article/contents/comments/register";
 import SecretCommment from "@/components/detail/article/contents/comments/secret";
 
-export default function Comment() {
+export default function Comment({ commentRef }: any) {
   return (
     <div
       id="comment"
-      className="flex w-full flex-col items-start gap-32 self-stretch pt-60"
+      className="relative flex w-full flex-col items-start gap-32 self-stretch pt-60"
     >
       <span>댓글</span>
       <div className="flex w-full flex-col items-start gap-40 self-stretch">
@@ -20,6 +20,7 @@ export default function Comment() {
           <RegisterComment />
         </div>
       </div>
+      <div ref={commentRef} className="absolute top-[750px] h-1 w-full"></div>
     </div>
   );
 }

--- a/components/detail/article/contents/destination/index.tsx
+++ b/components/detail/article/contents/destination/index.tsx
@@ -6,10 +6,11 @@ import { Location } from "@/components/form/writeForm";
 import GoogleMap from "@/components/googlemap";
 
 interface DestinationProps {
+  destinationRef: any;
   destination: string;
 }
 
-export default function Destination({}: DestinationProps) {
+export default function Destination({ destinationRef }: DestinationProps) {
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
   const [location, setLocation] = useState<Location>({
     lat: 37.5400456,
@@ -37,7 +38,7 @@ export default function Destination({}: DestinationProps) {
   return (
     <div
       id="destination"
-      className="flex w-full flex-col items-start gap-32 self-stretch pt-60"
+      className="relative flex w-full flex-col items-start gap-32 self-stretch pt-60"
     >
       <span>여행지</span>
       <div className="flex flex-col items-start gap-16 self-stretch">
@@ -53,6 +54,10 @@ export default function Destination({}: DestinationProps) {
           <GoogleMap location={location} />
         </div>
       </div>
+      <div
+        ref={destinationRef}
+        className="absolute top-[750px] h-1 w-full"
+      ></div>
     </div>
   );
 }

--- a/components/detail/article/contents/index.tsx
+++ b/components/detail/article/contents/index.tsx
@@ -1,3 +1,5 @@
+import { useInView } from "react-intersection-observer";
+
 import Comment from "@/components/detail/article/contents/comments/index";
 import Destination from "@/components/detail/article/contents/destination";
 import Images from "@/components/detail/article/contents/destination/descriptionImages";
@@ -5,14 +7,21 @@ import Recruitment from "@/components/detail/article/contents/recruitment";
 import Sort from "@/components/detail/article/contents/sort";
 
 export default function Content() {
+  const [recruitRef, recruitInView] = useInView();
+  const [destinationRef, destinationInView] = useInView();
+  const [commentRef, commentInView] = useInView();
   return (
     <div className="flex w-[956px] flex-col items-center">
-      <Sort />
+      <Sort
+        recruitInView={recruitInView}
+        destinationInView={destinationInView}
+        commentInView={commentInView}
+      />
       <div className="flex w-full flex-col items-start gap-60 rounded-bl-32 rounded-br-32 bg-white px-32 pb-80 pt-32 text-20 font-bold">
-        <Recruitment />
+        <Recruitment recruitRef={recruitRef} />
         <Images />
-        <Destination />
-        <Comment />
+        <Destination destinationRef={destinationRef} destination={""} />
+        <Comment commentRef={commentRef} />
       </div>
     </div>
   );

--- a/components/detail/article/contents/recruitment/index.tsx
+++ b/components/detail/article/contents/recruitment/index.tsx
@@ -1,11 +1,11 @@
 import Image from "next/image";
 
-export default function Recruitment() {
+export default function Recruitment({ recruitRef }: any) {
   const tags = ["태그1", "태그2", "태그3"];
   return (
     <div
       id="information"
-      className="flex w-full flex-col items-start gap-32 self-stretch pt-60"
+      className="relative flex w-full flex-col items-start gap-32 self-stretch pt-60"
     >
       <span>모집 정보</span>
       <div className="flex flex-col items-start gap-24 self-stretch text-16 font-normal">
@@ -46,6 +46,7 @@ export default function Recruitment() {
           </span>
         </div>
       </div>
+      <div ref={recruitRef} className="absolute top-[750px] h-1 w-full"></div>
     </div>
   );
 }

--- a/components/detail/article/contents/sort/index.tsx
+++ b/components/detail/article/contents/sort/index.tsx
@@ -17,7 +17,7 @@ export default function DetailSort() {
     background: selectedId === id ? "white" : "#e0f2fe",
   });
   return (
-    <div className="sticky top-0 z-50 flex w-full items-start gap-4 text-20 font-bold text-sky-600">
+    <div className="sticky top-0 z-10 flex w-full items-start gap-4 text-20 font-bold text-sky-600">
       <a
         className="flex h-60 w-1/3 justify-around rounded-tl-32 rounded-tr-32 border-none"
         href="#information"

--- a/components/detail/article/contents/sort/index.tsx
+++ b/components/detail/article/contents/sort/index.tsx
@@ -1,7 +1,21 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-export default function DetailSort() {
+export default function DetailSort({
+  recruitInView,
+  destinationInView,
+  commentInView,
+}: any) {
   const [selectedId, setSelectedId] = useState("information");
+
+  useEffect(() => {
+    if (recruitInView) {
+      setSelectedId("information");
+    } else if (destinationInView) {
+      setSelectedId("destination");
+    } else if (commentInView) {
+      setSelectedId("comment");
+    }
+  }, [recruitInView, destinationInView, commentInView]);
 
   const handleClick =
     (id: string) => (event: { preventDefault: () => void }) => {
@@ -16,6 +30,7 @@ export default function DetailSort() {
   const getLinkStyle = (id: string) => ({
     background: selectedId === id ? "white" : "#e0f2fe",
   });
+
   return (
     <div className="sticky top-0 z-10 flex w-full items-start gap-4 bg-sky-50 text-20 font-bold text-sky-600">
       <a

--- a/components/detail/article/contents/sort/index.tsx
+++ b/components/detail/article/contents/sort/index.tsx
@@ -17,7 +17,7 @@ export default function DetailSort() {
     background: selectedId === id ? "white" : "#e0f2fe",
   });
   return (
-    <div className="sticky top-0 z-10 flex w-full items-start gap-4 text-20 font-bold text-sky-600">
+    <div className="sticky top-0 z-10 flex w-full items-start gap-4 bg-sky-50 text-20 font-bold text-sky-600">
       <a
         className="flex h-60 w-1/3 justify-around rounded-tl-32 rounded-tr-32 border-none"
         href="#information"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "^18",
         "react-geocode": "^1.0.0-alpha.1",
         "react-hook-form": "^7.51.0",
+        "react-intersection-observer": "^9.8.1",
         "react-quill": "^2.0.0",
         "react-slick": "^0.30.2",
         "slick-carousel": "^1.8.1",
@@ -5046,6 +5047,20 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.8.1.tgz",
+      "integrity": "sha512-QzOFdROX8D8MH3wE3OVKH0f3mLjKTtEN1VX/rkNuECCff+aKky0pIjulDhr3Ewqj5el/L+MhBkM3ef0Tbt+qUQ==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^18",
     "react-geocode": "^1.0.0-alpha.1",
     "react-hook-form": "^7.51.0",
+    "react-intersection-observer": "^9.8.1",
     "react-quill": "^2.0.0",
     "react-slick": "^0.30.2",
     "slick-carousel": "^1.8.1",


### PR DESCRIPTION
# 관련사항
 - 상세페이지 디자인 수정 및 그에 필요한 기능 구현

# 뭐가 변했나요?

- react-intersection-observer을 활용해 스크롤 중 특정 영역에 도달 여부에 따라 각 필터 부분 배경이 바뀌는 기능 구현
- 필터 부분을 감싸는 컨테이너의 배경색을 주어 뒤 컨텐츠가 보이던 문제 해결
- 필터 부분 z-index를 수정해 모달, 태블릿 사이즈에서 프로필 sheet을 가리던 문제 해결

# 스크린샷

https://github.com/GilDongMu/gildongmu/assets/129366303/9f6e139c-e280-4945-bcfd-9bc16f0a132c

