### PR TITLE
캘린더 수정

### DIFF
--- a/components/form/input/ContentInput.tsx
+++ b/components/form/input/ContentInput.tsx
@@ -29,7 +29,7 @@ function ContentTextarea({
         id={id}
         value={text}
         onChange={e => setText(e.target.value)}
-        className={`h-[211px] w-full resize-none rounded-12 border border-line-02 bg-bg-02 px-16 py-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:h-[214px] mobile:text-sm ${isError && "border-0 bg-input-error"}`}
+        className={`h-[211px] w-full resize-none rounded-2xl border border-line-02 bg-bg-02 px-16 py-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:h-[214px] mobile:text-sm ${isError && "border-0 bg-input-error"}`}
         placeholder="모집 내용을 작성해 주세요"
       />
     </div>

--- a/components/form/input/CounterInput.tsx
+++ b/components/form/input/CounterInput.tsx
@@ -46,7 +46,7 @@ function CounterInput({
       <Button
         type="button"
         variant={count <= 0 ? "ghost" : "outline"}
-        className="rounded-ful h-44 w-44 border-2 tablet:h-36 tablet:w-36"
+        className="h-44 w-44 rounded-full border-2 tablet:h-36 tablet:w-36"
         onClick={handleDecrement}
       >
         -

--- a/components/form/input/DatePickerInput.tsx
+++ b/components/form/input/DatePickerInput.tsx
@@ -2,8 +2,9 @@ import "react-day-picker/dist/style.css";
 
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { DayPicker } from "react-day-picker";
+import { useOnClickOutside } from "usehooks-ts";
 
 import { Input } from "@/components/ui/input";
 
@@ -12,11 +13,16 @@ function DatePickerInput({
   value,
   id,
 }: {
-  onChange: (dateString: string) => void; 
+  onChange: (dateString: string) => void;
   value: any;
   id: string;
 }) {
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const today = new Date();
+  const disabledDays = { after: today };
+
   const formattedDate = value
     ? format(value, "yyyy년 MM월 dd일", { locale: ko })
     : "";
@@ -34,6 +40,10 @@ function DatePickerInput({
     setIsPickerOpen(false);
   };
 
+  useOnClickOutside(ref, () => {
+    isPickerOpen && setIsPickerOpen(false);
+  });
+
   const css = `
     .my-selected {
       color: #fff;
@@ -50,13 +60,14 @@ function DatePickerInput({
           readOnly
           onClick={handleInputClick}
           placeholder="생년월일 입력"
-          className="h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
+          className="h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
         />
         {isPickerOpen && (
-          <div className="absolute top-full z-10 bg-white">
+          <div ref={ref} className="absolute top-60 z-10 rounded-2xl bg-white">
             <style>{css}</style>
             <DayPicker
               mode="single"
+              defaultMonth={new Date(1990, 0)}
               selected={value}
               onSelect={handleDaySelect}
               fromYear={1900}
@@ -68,6 +79,8 @@ function DatePickerInput({
               modifiersClassNames={{
                 selected: "my-selected",
               }}
+              className="rounded-2xl p-10 shadow-md"
+              disabled={disabledDays}
             />
           </div>
         )}

--- a/components/form/input/IntroTextarea.tsx
+++ b/components/form/input/IntroTextarea.tsx
@@ -31,7 +31,7 @@ function IntroTextarea({
         id={id}
         value={text}
         onChange={handleChange}
-        className="h-137 w-full resize-none rounded-12 border border-line-02 bg-bg-02 px-16 py-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
+        className="h-137 w-full resize-none rounded-2xl border border-line-02 bg-bg-02 px-16 py-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
         placeholder="자기소개를 입력해 주세요"
       />
       <p className="mt-1 self-end text-sm text-gray-500">

--- a/components/form/input/RangeDatePickerInput.tsx
+++ b/components/form/input/RangeDatePickerInput.tsx
@@ -1,9 +1,10 @@
 import "react-day-picker/dist/style.css";
 
-import { format } from "date-fns";
+import { differenceInCalendarDays, format } from "date-fns";
 import { ko } from "date-fns/locale";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { DateRange, DayPicker } from "react-day-picker";
+import { useOnClickOutside } from "usehooks-ts";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -18,14 +19,26 @@ function RangeDatePickerInput({
   const [range, setRange] = useState<DateRange | undefined>();
   const [inputValue, setInputValue] = useState("");
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [totalDays, setTotalDays] = useState(0);
 
   const today = new Date();
+  const disabledDays = { before: today };
+
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (range?.from && range?.to) {
-      const formattedFrom = format(range.from, "yyyy년 MM월 dd일");
-      const formattedTo = format(range.to, "yyyy년 MM월 dd일");
-      setInputValue(`${formattedFrom} – ${formattedTo}`);
+      const days = differenceInCalendarDays(range.to, range.from) + 1;
+      setTotalDays(days);
+
+      const formattedFrom = format(range.from, "yyyy년 MM월 dd일", {
+        locale: ko,
+      });
+      const formattedTo = format(range.to, "yyyy년 MM월 dd일", { locale: ko });
+      setInputValue(`${formattedFrom} – ${formattedTo} (${days}일)`);
+    } else {
+      setInputValue("");
+      setTotalDays(0);
     }
   }, [range]);
 
@@ -41,6 +54,14 @@ function RangeDatePickerInput({
       console.error("날짜 데이터 전송 오류");
     }
     setIsPickerOpen(false);
+  };
+
+  useOnClickOutside(ref, () => {
+    isPickerOpen && setIsPickerOpen(false);
+  });
+
+  const resetSelection = () => {
+    setRange(undefined);
   };
 
   const css = `
@@ -64,13 +85,14 @@ function RangeDatePickerInput({
         />
         <style>{css}</style>
         {isPickerOpen && (
-          <div className="absolute top-full z-10 bg-white">
+          <div ref={ref} className="absolute top-60 z-10 rounded-2xl bg-white">
             <div className="relative">
               <DayPicker
                 mode="range"
                 defaultMonth={today}
                 selected={range}
                 onSelect={setRange}
+                numberOfMonths={2}
                 fromYear={2024}
                 toYear={2035}
                 captionLayout="dropdown-buttons"
@@ -80,13 +102,22 @@ function RangeDatePickerInput({
                 modifiersClassNames={{
                   selected: "my-selected",
                 }}
-                className="h-[330px]"
+                className="h-[370px] rounded-2xl p-10 shadow-md"
+                disabled={disabledDays}
               />
               <Button
                 onClick={handleSelectButton}
-                className="absolute -bottom-10 right-20 h-25 w-35 rounded-15 text-xs"
+                className=" absolute bottom-10 right-10 h-35 w-50 rounded-2xl text-xs"
               >
                 선택
+              </Button>
+              <Button
+                type="button"
+                onClick={resetSelection}
+                className=" absolute bottom-10 right-70 h-35 w-70 rounded-2xl text-xs"
+                variant={"outline"}
+              >
+                날짜 초기화
               </Button>
             </div>
           </div>

--- a/components/form/input/RangeDatePickerInput.tsx
+++ b/components/form/input/RangeDatePickerInput.tsx
@@ -60,7 +60,7 @@ function RangeDatePickerInput({
           readOnly
           placeholder="여행 일정을 선택해 주세요"
           onClick={() => setIsPickerOpen(true)}
-          className="h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
+          className="h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
         />
         <style>{css}</style>
         {isPickerOpen && (

--- a/components/form/input/TagInput.tsx
+++ b/components/form/input/TagInput.tsx
@@ -76,7 +76,7 @@ function TagInput({
       <Input
         type="text"
         id={id}
-        className="mb-5 h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
+        className="mb-5 h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm"
         value={inputValue}
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}

--- a/components/form/signupForm/index.tsx
+++ b/components/form/signupForm/index.tsx
@@ -267,6 +267,7 @@ function SignUpForm() {
                 render={({ field }) => (
                   <DatePickerInput
                     onChange={(date: any) => field.onChange(date)}
+                    value={field.value}
                     id={"date"}
                   />
                 )}

--- a/components/form/signupForm/index.tsx
+++ b/components/form/signupForm/index.tsx
@@ -117,7 +117,7 @@ function SignUpForm() {
               <Input
                 id="email"
                 type="email"
-                className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.email && "border-0 bg-input-error"}`}
+                className={`h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.email && "border-0 bg-input-error"}`}
                 placeholder="이메일을 입력해 주세요"
                 {...register("email", { required: true, pattern: regEmail })}
               />
@@ -139,7 +139,7 @@ function SignUpForm() {
               <Input
                 id="nickname"
                 type="text"
-                className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.nickname && "border-0 bg-input-error"}`}
+                className={`h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.nickname && "border-0 bg-input-error"}`}
                 placeholder="닉네임을 입력해 주세요"
                 {...register("nickname", {
                   required: true,
@@ -171,7 +171,7 @@ function SignUpForm() {
                 <Input
                   id="password"
                   type={passwordShown ? "text" : "password"}
-                  className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.password && "border-0 bg-input-error text-text-02"}`}
+                  className={`h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.password && "border-0 bg-input-error text-text-02"}`}
                   placeholder="비밀번호를 입력해 주세요"
                   {...register("password", {
                     required: true,
@@ -211,7 +211,7 @@ function SignUpForm() {
                 <Input
                   id="confimPassword"
                   type={confirmPasswordShown ? "text" : "password"}
-                  className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.confirmPassword && "border-0 bg-input-error"}`}
+                  className={`h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.confirmPassword && "border-0 bg-input-error"}`}
                   placeholder="비밀번호를 다시 입력해 주세요"
                   {...register("confirmPassword", {
                     required: true,
@@ -267,7 +267,6 @@ function SignUpForm() {
                 render={({ field }) => (
                   <DatePickerInput
                     onChange={(date: any) => field.onChange(date)}
-                    value={field.value}
                     id={"date"}
                   />
                 )}

--- a/components/form/writeForm/index.tsx
+++ b/components/form/writeForm/index.tsx
@@ -94,7 +94,7 @@ function WriteForm() {
               </Label>
               <Input
                 placeholder="여행지 입력"
-                className="h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272"
+                className="h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272"
                 onKeyPress={handleSearchLocation}
               />
               <div className="h-[240px] w-[756px] rounded-12 bg-line-02 tablet:w-[672px] mobile:w-272">

--- a/components/googlemap/index.tsx
+++ b/components/googlemap/index.tsx
@@ -35,5 +35,5 @@ export default function GoogleMap({ location }: GoogleMapProps) {
     initMap();
   }, [location, apiKey]);
 
-  return <div id="map" className="h-full w-full rounded-12" ref={mapRef} />;
+  return <div id="map" className="h-full w-full rounded-2xl" ref={mapRef} />;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@types/google.maps": "^3.55.4",
         "@types/node": "^20",
         "@types/react": "^18",
+        "@types/react-datepicker": "^6.2.0",
         "@types/react-dom": "^18",
         "@types/react-slick": "^0.23.13",
         "@typescript-eslint/parser": "^7.1.0",
@@ -1221,6 +1222,17 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-datepicker": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-6.2.0.tgz",
+      "integrity": "sha512-+JtO4Fm97WLkJTH8j8/v3Ldh7JCNRwjMYjRaKh4KHH0M3jJoXtwiD3JBCsdlg3tsFIw9eQSqyAPeVDN2H2oM9Q==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/react": "^0.26.2",
+        "@types/react": "*",
+        "date-fns": "^3.3.1"
       }
     },
     "node_modules/@types/react-dom": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/google.maps": "^3.55.4",
     "@types/node": "^20",
     "@types/react": "^18",
+    "@types/react-datepicker": "^6.2.0",
     "@types/react-dom": "^18",
     "@types/react-slick": "^0.23.13",
     "@typescript-eslint/parser": "^7.1.0",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,7 +4,8 @@
 
 @font-face {
   font-family: "NanumSquareRound";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_two@1.0/NanumSquareRound.woff") format("woff");
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_two@1.0/NanumSquareRound.woff")
+    format("woff");
   font-weight: normal;
   font-style: normal;
 }
@@ -15,9 +16,11 @@
   }
 }
 
-@layer components {}
+@layer components {
+}
 
-@layer utilities {}
+@layer utilities {
+}
 
 @layer base {
   :root {
@@ -176,4 +179,14 @@
 .heartRotate {
   transition: transform 0.6s ease-in-out;
   transform: rotateY(180deg);
+}
+
+* {
+  --rdp-cell-size: 40px; /* Size of the day cells. */
+  --rdp-caption-font-size: 18px; /* Font size for the caption labels. */
+  --rdp-accent-color: #14b8a6; /* Accent color for the background of selected days. */
+  --rdp-background-color: #2dd4bf; /* Background color for the hovered/focused elements. */
+}
+.rdp {
+  margin: 0 !important;
 }


### PR DESCRIPTION
# 관련사항
- 캘린더 수정 및 회원가입/글쓰기 페이지 인풋 border-radius 수정

# 뭐가 변했나요?
- 캘린더 디자인 수정 (box-shadow, hover color)
- 글쓰기 페이지 캘린더 2페이지로 수정, 날짜 초기화 추가, 총 일수 추가
- useRef 추가
- 각 캘린더 특성에 맞는 disabledDays 추가
- 피그마 디자인에 맞춰 인풋 border-radius 수정

# 특이사항
- 총 일수, 날짜 초기화 기능은 필요하다고 생각해서 추가했습니다. 더 좋은 의견 있으면 말씀해주세요!

# 스크린샷
<img width="366" alt="스크린샷 2024-03-21 오전 12 10 29" src="https://github.com/GilDongMu/gildongmu/assets/137983583/cefe767a-dd33-44ed-972b-1251a01d7e95">

https://github.com/GilDongMu/gildongmu/assets/137983583/9eeb21c1-2747-4190-be65-3b2f709009f4
