### PR TITLE
소셜 로그인 완료

### DIFF
--- a/components/form/socialSignupForm/index.tsx
+++ b/components/form/socialSignupForm/index.tsx
@@ -2,7 +2,7 @@ import "react-datepicker/dist/react-datepicker.css";
 
 import Image from "next/image";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import DatePickerInput from "@/components/form/input/DatePickerInput";
@@ -14,13 +14,12 @@ import Modal from "@/components/modal";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import axios from "@/lib/api/axios";
-import { regEmail, regPassword } from "@/lib/utils/regexp";
+import { regPassword } from "@/lib/utils/regexp";
 
 interface SignUp {
   bio?: string;
   confirmPassword: string;
   dayOfBirth: string;
-  email: string;
   favoriteSpots?: string[];
   gender: "MALE" | "FEMALE";
   nickname: string;
@@ -28,7 +27,7 @@ interface SignUp {
   profile?: string;
 }
 
-function SocialSignUpForm({ oauth2Email }: { oauth2Email: string }) {
+function SocialSignUpForm() {
   const {
     register,
     handleSubmit,
@@ -45,6 +44,8 @@ function SocialSignUpForm({ oauth2Email }: { oauth2Email: string }) {
   const [confirmPasswordShown, setConfirmPasswordShown] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isCheckEmailModalOpen, setIsCheckEmailModalOpen] = useState(false);
+
+  const [oauthEmail, setOauthEmail] = useState("default@email.com");
 
   const togglePasswordVisiblity = () => {
     setPasswordShown(passwordShown => !passwordShown);
@@ -83,6 +84,21 @@ function SocialSignUpForm({ oauth2Email }: { oauth2Email: string }) {
     onSubmit(data);
   };
 
+  useEffect(() => {
+    const fetchLoginStatus = async () => {
+      try {
+        const response = await axios.get("/oauth2/siginup");
+        setOauthEmail(response.data.email);
+
+        console.log("oauth2 이메일 조회 성공! ", response.data.email);
+      } catch (error) {
+        console.error("oauth2 이메일 조회 실패", error);
+      }
+    };
+
+    fetchLoginStatus();
+  }, [oauthEmail, router]);
+
   return (
     <>
       <form onSubmit={handleSubmit(handleFormSubmit)}>
@@ -96,15 +112,12 @@ function SocialSignUpForm({ oauth2Email }: { oauth2Email: string }) {
           </div>
           <div className="flex flex-col gap-24">
             <div className="flex flex-col gap-8">
-              <Label htmlFor="email">
-                이메일<span className="text-pink-500">*</span>
-              </Label>
+              <Label htmlFor="email">이메일</Label>
               <Input
                 id="email"
                 type="email"
                 className={`h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.email && "border-0 bg-input-error"}`}
-                value={oauth2Email}
-                {...register("email", { required: true, pattern: regEmail })}
+                placeholder={oauthEmail}
                 disabled
               />
             </div>

--- a/components/form/socialSignupForm/index.tsx
+++ b/components/form/socialSignupForm/index.tsx
@@ -10,7 +10,7 @@ import ImageUpload from "@/components/form/input/ImageUploadInput";
 import IntroTextarea from "@/components/form/input/IntroTextarea";
 import RadioInput from "@/components/form/input/RadioInput";
 import TagInput from "@/components/form/input/TagInput";
-import AlertModal from "@/components/modal";
+import Modal from "@/components/modal";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import axios from "@/lib/api/axios";
@@ -28,7 +28,7 @@ interface SignUp {
   profile?: string;
 }
 
-function SignUpForm() {
+function SocialSignUpForm({ oauth2Email }: { oauth2Email: string }) {
   const {
     register,
     handleSubmit,
@@ -52,21 +52,6 @@ function SignUpForm() {
 
   const toggleConfirmPasswordVisibility = () => {
     setConfirmPasswordShown(confirmPasswordShown => !confirmPasswordShown);
-  };
-
-  const checkEmail = async (data: SignUp) => {
-    try {
-      const emailCheckResponse = await axios.post("/auth/check-email", {
-        email: data.email,
-      });
-      if (emailCheckResponse.data.isUsable) {
-        await onSubmit(data);
-      } else {
-        setIsCheckEmailModalOpen(true);
-      }
-    } catch (error) {
-      console.error("이메일 확인 중 오류 발생:", error);
-    }
   };
 
   const onSubmit = async (data: SignUp) => {
@@ -95,7 +80,7 @@ function SignUpForm() {
   };
 
   const handleFormSubmit = (data: SignUp) => {
-    checkEmail(data);
+    onSubmit(data);
   };
 
   return (
@@ -117,20 +102,11 @@ function SignUpForm() {
               <Input
                 id="email"
                 type="email"
-                className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.email && "border-0 bg-input-error"}`}
-                placeholder="이메일을 입력해 주세요"
+                className={`h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.email && "border-0 bg-input-error"}`}
+                value={oauth2Email}
                 {...register("email", { required: true, pattern: regEmail })}
+                disabled
               />
-              {errors.email && errors.email.type === "required" && (
-                <span className="text-12 text-system-error">
-                  이메일을 입력해 주세요
-                </span>
-              )}
-              {errors.email && errors.email.type === "pattern" && (
-                <span className="text-12 text-system-error">
-                  이메일 형식으로 작성해 주세요
-                </span>
-              )}
             </div>
             <div className="flex flex-col gap-8">
               <Label htmlFor="nickname">
@@ -139,7 +115,7 @@ function SignUpForm() {
               <Input
                 id="nickname"
                 type="text"
-                className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.nickname && "border-0 bg-input-error"}`}
+                className={`h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.nickname && "border-0 bg-input-error"}`}
                 placeholder="닉네임을 입력해 주세요"
                 {...register("nickname", {
                   required: true,
@@ -171,7 +147,7 @@ function SignUpForm() {
                 <Input
                   id="password"
                   type={passwordShown ? "text" : "password"}
-                  className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.password && "border-0 bg-input-error text-text-02"}`}
+                  className={`h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.password && "border-0 bg-input-error text-text-02"}`}
                   placeholder="비밀번호를 입력해 주세요"
                   {...register("password", {
                     required: true,
@@ -211,7 +187,7 @@ function SignUpForm() {
                 <Input
                   id="confimPassword"
                   type={confirmPasswordShown ? "text" : "password"}
-                  className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.confirmPassword && "border-0 bg-input-error"}`}
+                  className={`h-52 w-[756px] rounded-2xl border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.confirmPassword && "border-0 bg-input-error"}`}
                   placeholder="비밀번호를 다시 입력해 주세요"
                   {...register("confirmPassword", {
                     required: true,
@@ -334,7 +310,7 @@ function SignUpForm() {
         </div>
       </form>
       {isModalOpen && (
-        <AlertModal
+        <Modal
           modalType="signupSuccess"
           onClose={() => {
             setIsModalOpen(false);
@@ -343,7 +319,7 @@ function SignUpForm() {
         />
       )}
       {isCheckEmailModalOpen && (
-        <AlertModal
+        <Modal
           modalType="emailInUse"
           onClose={() => {
             setIsCheckEmailModalOpen(false);
@@ -354,4 +330,4 @@ function SignUpForm() {
   );
 }
 
-export default SignUpForm;
+export default SocialSignUpForm;

--- a/components/form/socialSignupForm/index.tsx
+++ b/components/form/socialSignupForm/index.tsx
@@ -1,0 +1,357 @@
+import "react-datepicker/dist/react-datepicker.css";
+
+import Image from "next/image";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+import DatePickerInput from "@/components/form/input/DatePickerInput";
+import ImageUpload from "@/components/form/input/ImageUploadInput";
+import IntroTextarea from "@/components/form/input/IntroTextarea";
+import RadioInput from "@/components/form/input/RadioInput";
+import TagInput from "@/components/form/input/TagInput";
+import AlertModal from "@/components/modal";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import axios from "@/lib/api/axios";
+import { regEmail, regPassword } from "@/lib/utils/regexp";
+
+interface SignUp {
+  bio?: string;
+  confirmPassword: string;
+  dayOfBirth: string;
+  email: string;
+  favoriteSpots?: string[];
+  gender: "MALE" | "FEMALE";
+  nickname: string;
+  password: string;
+  profile?: string;
+}
+
+function SignUpForm() {
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors, isValid },
+    watch,
+  } = useForm<SignUp>({ mode: "onBlur" });
+
+  const router = useRouter();
+
+  const password = watch("password", "");
+
+  const [passwordShown, setPasswordShown] = useState(false);
+  const [confirmPasswordShown, setConfirmPasswordShown] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isCheckEmailModalOpen, setIsCheckEmailModalOpen] = useState(false);
+
+  const togglePasswordVisiblity = () => {
+    setPasswordShown(passwordShown => !passwordShown);
+  };
+
+  const toggleConfirmPasswordVisibility = () => {
+    setConfirmPasswordShown(confirmPasswordShown => !confirmPasswordShown);
+  };
+
+  const checkEmail = async (data: SignUp) => {
+    try {
+      const emailCheckResponse = await axios.post("/auth/check-email", {
+        email: data.email,
+      });
+      if (emailCheckResponse.data.isUsable) {
+        await onSubmit(data);
+      } else {
+        setIsCheckEmailModalOpen(true);
+      }
+    } catch (error) {
+      console.error("이메일 확인 중 오류 발생:", error);
+    }
+  };
+
+  const onSubmit = async (data: SignUp) => {
+    const formData = new FormData();
+
+    const { confirmPassword, profile, ...submitData } = data;
+    formData.append(
+      "request",
+      new Blob([JSON.stringify(submitData)], { type: "application/json" }),
+    );
+
+    if (data.profile) {
+      formData.append("profile", data.profile);
+    }
+
+    try {
+      const res = await axios.post("/oauth2/signup", formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      });
+      setIsModalOpen(true);
+    } catch (error) {
+      console.error("회원가입 실패:", error);
+    }
+  };
+
+  const handleFormSubmit = (data: SignUp) => {
+    checkEmail(data);
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        <div className="flex w-[956px] flex-col items-center rounded-32 bg-white px-32 py-48 tablet:w-[720px] mobile:w-[312px]">
+          <div className="mb-40 flex items-center gap-32 tablet:gap-28">
+            <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
+            <div className="text-18 tablet:text-16 mobile:text-14">
+              필수 정보 입력
+            </div>
+            <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
+          </div>
+          <div className="flex flex-col gap-24">
+            <div className="flex flex-col gap-8">
+              <Label htmlFor="email">
+                이메일<span className="text-pink-500">*</span>
+              </Label>
+              <Input
+                id="email"
+                type="email"
+                className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.email && "border-0 bg-input-error"}`}
+                placeholder="이메일을 입력해 주세요"
+                {...register("email", { required: true, pattern: regEmail })}
+              />
+              {errors.email && errors.email.type === "required" && (
+                <span className="text-12 text-system-error">
+                  이메일을 입력해 주세요
+                </span>
+              )}
+              {errors.email && errors.email.type === "pattern" && (
+                <span className="text-12 text-system-error">
+                  이메일 형식으로 작성해 주세요
+                </span>
+              )}
+            </div>
+            <div className="flex flex-col gap-8">
+              <Label htmlFor="nickname">
+                닉네임<span className="text-pink-500">*</span>
+              </Label>
+              <Input
+                id="nickname"
+                type="text"
+                className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.nickname && "border-0 bg-input-error"}`}
+                placeholder="닉네임을 입력해 주세요"
+                {...register("nickname", {
+                  required: true,
+                  minLength: 2,
+                  maxLength: 8,
+                })}
+              />
+              {errors.nickname && errors.nickname.type === "required" && (
+                <span className="text-12 text-system-error">
+                  닉네임을 입력해 주세요
+                </span>
+              )}
+              {errors.nickname && errors.nickname.type === "minLength" && (
+                <span className="text-12 text-system-error">
+                  닉네임은 최소 2글자 입니다
+                </span>
+              )}
+              {errors.nickname && errors.nickname.type === "maxLength" && (
+                <span className="text-12 text-system-error">
+                  닉네임은 최대 8글자 입니다
+                </span>
+              )}
+            </div>
+            <div className="flex flex-col gap-8">
+              <Label htmlFor="password">
+                비밀번호<span className="text-pink-500">*</span>
+              </Label>
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={passwordShown ? "text" : "password"}
+                  className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.password && "border-0 bg-input-error text-text-02"}`}
+                  placeholder="비밀번호를 입력해 주세요"
+                  {...register("password", {
+                    required: true,
+                    pattern: regPassword,
+                  })}
+                />
+                <div className="absolute inset-y-0 right-0 flex h-full items-center justify-center px-16">
+                  <button
+                    type="button"
+                    onClick={togglePasswordVisiblity}
+                    className="relative h-24 w-24"
+                  >
+                    <Image
+                      src={`/icons/eye-${passwordShown ? "on" : "off"}.png`}
+                      fill
+                      alt="eye-icon"
+                    />
+                  </button>
+                </div>
+              </div>
+              {errors.password && errors.password.type === "required" && (
+                <span className="text-12 text-system-error">
+                  비밀번호를 입력해 주세요
+                </span>
+              )}
+              {errors.password && errors.password.type === "pattern" && (
+                <span className="text-12 text-system-error">
+                  영어, 숫자, 특수문자를 조합하여 8자리 이상 입력해 주세요
+                </span>
+              )}
+            </div>
+            <div className="flex flex-col gap-8">
+              <Label htmlFor="confimPassword">
+                비밀번호 확인<span className="text-pink-500">*</span>
+              </Label>
+              <div className="relative">
+                <Input
+                  id="confimPassword"
+                  type={confirmPasswordShown ? "text" : "password"}
+                  className={`h-52 w-[756px] rounded-12 border border-line-02 bg-bg-02 px-16 placeholder:text-text-05 focus:border focus:border-line-01 focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0 tablet:w-[672px] mobile:w-272 mobile:text-sm ${errors.confirmPassword && "border-0 bg-input-error"}`}
+                  placeholder="비밀번호를 다시 입력해 주세요"
+                  {...register("confirmPassword", {
+                    required: true,
+                    validate: value => value === password,
+                  })}
+                />
+                <div className="absolute inset-y-0 right-0 flex h-full items-center justify-center px-16">
+                  <button
+                    type="button"
+                    onClick={toggleConfirmPasswordVisibility}
+                    className="relative h-24 w-24"
+                  >
+                    <Image
+                      src={`/icons/eye-${confirmPasswordShown ? "on" : "off"}.png`}
+                      fill
+                      alt="eye-icon"
+                    />
+                  </button>
+                </div>
+              </div>
+              {errors.confirmPassword && (
+                <span className="text-12 text-system-error">
+                  비밀번호가 일치하지 않습니다
+                </span>
+              )}
+            </div>
+            <div className="flex flex-col gap-8">
+              <Label htmlFor="gender">
+                성별<span className="text-pink-500">*</span>
+              </Label>
+              <Controller
+                control={control}
+                name="gender"
+                rules={{ required: true }}
+                render={({ field }) => (
+                  <RadioInput
+                    onChange={(gender: any) => field.onChange(gender)}
+                    value={field.value}
+                    pageType="singUp"
+                    id={"gender"}
+                  />
+                )}
+              />
+            </div>
+            <div className="flex flex-col gap-8">
+              <Label htmlFor="date">
+                생년월일<span className="text-pink-500">*</span>
+              </Label>
+              <Controller
+                control={control}
+                name="dayOfBirth"
+                rules={{ required: true }}
+                render={({ field }) => (
+                  <DatePickerInput
+                    onChange={(date: any) => field.onChange(date)}
+                    value={field.value}
+                    id={"date"}
+                  />
+                )}
+              />
+            </div>
+          </div>
+          <div className="my-40 flex items-center gap-32 tablet:gap-28">
+            <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
+            <div className="text-18 tablet:text-16 mobile:text-14">
+              추가 정보 입력
+            </div>
+            <div className="h-px w-294 bg-line-02 tablet:w-248 mobile:w-52"></div>
+          </div>
+          <div className="flex flex-col items-center gap-24">
+            <Controller
+              control={control}
+              name="profile"
+              render={({ field }) => (
+                <ImageUpload
+                  onChange={profile => field.onChange(profile)}
+                  value={field.value ?? ""}
+                />
+              )}
+            />
+            <div className="flex flex-col gap-8">
+              <Label htmlFor="tags">좋아하는 여행지</Label>
+              <Controller
+                control={control}
+                name="favoriteSpots"
+                render={({ field }) => (
+                  <TagInput
+                    onChange={(tags: any) => field.onChange(tags)}
+                    value={field.value}
+                    formType={"signUp"}
+                    id={"tags"}
+                  />
+                )}
+              />
+            </div>
+            <div className="flex flex-col gap-8">
+              <Label htmlFor="bio">자기소개</Label>
+              <Controller
+                control={control}
+                name="bio"
+                render={({ field }) => (
+                  <IntroTextarea
+                    onChange={text => field.onChange(text)}
+                    value={field.value ?? ""}
+                    id={"bio"}
+                  />
+                )}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="mt-40 flex w-[956px] flex-col items-center rounded-32 tablet:w-[720px] mobile:w-[312px]">
+          <button
+            type="submit"
+            disabled={!isValid}
+            className="flex h-52 w-240 items-center justify-center rounded-32 bg-primary text-white hover:bg-primary-press disabled:bg-line-02 disabled:text-text-04 mobile:h-44 mobile:w-180"
+          >
+            가입하기
+          </button>
+        </div>
+      </form>
+      {isModalOpen && (
+        <AlertModal
+          modalType="signupSuccess"
+          onClose={() => {
+            setIsModalOpen(false);
+            router.push("/login");
+          }}
+        />
+      )}
+      {isCheckEmailModalOpen && (
+        <AlertModal
+          modalType="emailInUse"
+          onClose={() => {
+            setIsCheckEmailModalOpen(false);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+export default SignUpForm;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -24,7 +24,6 @@ export default function Login() {
     reValidateMode: "onBlur", // 포커스 아웃 시 재검증
   });
   const router = useRouter();
-  const { code } = router.query; // URL에서 'code' 쿼리 파라미터 가져오기
 
   // 인풋이 비어있지 않을 때 로그인 버튼 활성화
   const email = watch("email");

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,39 +1,30 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 
 import Modal from "@/components/modal";
 import { Button } from "@/components/ui/button";
 import useToggle from "@/hooks/useToggle";
-import axiosInstance from "@/lib/api/axios";
+import axios from "@/lib/api/axios";
 import { regEmail, regPassword } from "@/lib/utils/regexp";
 
 export default function Login() {
-  const router = useRouter();
   const [loginErrorModal, setLoginErrorModal] = useState(false);
   const [eye, setEye, toggleEye] = useToggle(true);
   const {
     register,
     handleSubmit,
     watch,
-    formState: { isValid, errors },
+    formState: { errors },
   } = useForm({
     mode: "onBlur", // 포커스 아웃 시 유효성 검사
     criteriaMode: "all", // 모든 유효성 검사 규칙 체크
     reValidateMode: "onBlur", // 포커스 아웃 시 재검증
   });
-
-  // 카카오 로그인
-  const kakaoClientName = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID;
-  const kakaoRedirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI;
-  const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${kakaoClientName}&redirect_uri=${kakaoRedirectUri}&response_type=code`;
-
-  // 구글 로그인
-  const googleClientName = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
-  const googleRedirectUri = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI;
-  const GOOGLE_AUTH_URL = `https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=${googleClientName}&redirect_uri=${googleRedirectUri}&scope=https://www.googleapis.com/auth/userinfo.email`;
+  const router = useRouter();
+  const { code } = router.query; // URL에서 'code' 쿼리 파라미터 가져오기
 
   // 인풋이 비어있지 않을 때 로그인 버튼 활성화
   const email = watch("email");
@@ -42,7 +33,7 @@ export default function Login() {
 
   const onSubmit = async (data: any) => {
     try {
-      const response = await axiosInstance.post("/auth/login", {
+      const response = await axios.post("/auth/login", {
         email: data.email,
         password: data.password,
       });
@@ -59,29 +50,6 @@ export default function Login() {
       console.log(error.message);
     }
   };
-
-  useEffect(() => {
-    const sendDataToServer = async (data: any) => {
-      try {
-        const response = await axiosInstance.post(`/oauth2/login`, {
-          data,
-        });
-        console.log("소설로그인 성공", response.data);
-
-        router.push("/");
-      } catch (error) {
-        console.error("인증 코드 전송 실패:", error);
-        // 에러 처리 로직 (토큰 만료, 서버 응답 없음 등)
-      }
-    };
-
-    // URL에서 인증 코드 추출
-    const authCode = new URL(window.location.href).searchParams.get("code");
-    if (authCode) {
-      // 인증 코드가 있으면 백엔드로 전송
-      sendDataToServer(authCode);
-    }
-  }, []);
 
   return (
     <>
@@ -173,7 +141,10 @@ export default function Login() {
             </div>
 
             <div className="flex w-full items-center justify-between text-18">
-              <Link href={KAKAO_AUTH_URL} className="mr-20 w-1/2">
+              <Link
+                href={"http://3.38.76.39:8080/oauth2/authorization/kakao"}
+                className="mr-20 w-1/2"
+              >
                 <Button
                   variant="destructive"
                   className="hover:bg-curent h-52 w-full bg-kakao text-text-02"
@@ -189,7 +160,10 @@ export default function Login() {
                 </Button>
               </Link>
 
-              <Link href={GOOGLE_AUTH_URL} className="w-1/2">
+              <Link
+                href={"http://3.38.76.39:8080/oauth2/authorization/google"}
+                className="w-1/2"
+              >
                 <Button
                   variant="destructive"
                   className="hover:bg-curent h-52 w-full bg-bg-02 text-text-02"

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -38,7 +38,7 @@ export default function Login() {
       });
 
       const { accessToken } = response.data;
-      document.cookie = `accessToken=${accessToken}; path=/; max-age=3600; secure; samesite=strict`;
+      document.cookie = `accessToken=${accessToken}; path=/; max-age=86400; secure; samesite=strict`;
 
       router.push("/");
     } catch (error: any) {

--- a/pages/oauth2/login/index.tsx
+++ b/pages/oauth2/login/index.tsx
@@ -12,7 +12,7 @@ export default function Oauth2Login() {
         const response = await axios.get("/oauth2/login");
 
         const { oauth2Token } = response.data;
-        document.cookie = `accessToken=${oauth2Token}; path=/; max-age=3600; secure; samesite=strict`;
+        document.cookie = `accessToken=${oauth2Token}; path=/; max-age=86400; secure; samesite=strict`;
 
         console.log("oauth2 토큰 저장 성공!");
         router.push("/");

--- a/pages/oauth2/login/index.tsx
+++ b/pages/oauth2/login/index.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import axios from "@/lib/api/axios";
+
+export default function Oauth2Login() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchLoginStatus = async () => {
+      try {
+        const response = await axios.get("/oauth2/login");
+
+        const { oauth2Token } = response.data;
+        document.cookie = `accessToken=${oauth2Token}; path=/; max-age=3600; secure; samesite=strict`;
+
+        console.log("oauth2 토큰 저장 성공!");
+        router.push("/");
+      } catch (error) {
+        console.error("oauth2 토큰 저장 실패", error);
+      }
+    };
+
+    fetchLoginStatus();
+  }, [router]);
+
+  return (
+    <div>
+      <h1>Oauth2 Login...</h1>
+    </div>
+  );
+}

--- a/pages/oauth2/signup/index.tsx
+++ b/pages/oauth2/signup/index.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import SocialSignUpForm from "@/components/form/socialSignupForm";
+import axios from "@/lib/api/axios";
+
+export default function Oauth2Signup() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchLoginStatus = async () => {
+      try {
+        const response = await axios.get("/oauth2/siginup");
+        const oauth2Email = response.data.email;
+
+        console.log("oauth2 이메일 조회 성공! ", response.data);
+      } catch (error) {
+        console.error("oauth2 이메일 조회 실패", error);
+      }
+    };
+
+    fetchLoginStatus();
+  }, [router]);
+
+  return (
+    <div className="flex flex-col items-center justify-start bg-bg-06 pb-80">
+      <h1 className="flex h-120 items-center text-32 font-extrabold text-text-01 tablet:h-100 tablet:text-24">
+        회원 추가 정보
+      </h1>
+      <SocialSignUpForm />
+    </div>
+  );
+}

--- a/pages/oauth2/signup/index.tsx
+++ b/pages/oauth2/signup/index.tsx
@@ -1,34 +1,16 @@
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
 
 import SocialSignUpForm from "@/components/form/socialSignupForm";
-import axios from "@/lib/api/axios";
 
 export default function Oauth2Signup() {
   const router = useRouter();
-  const [email, setEmail] = useState("");
-
-  useEffect(() => {
-    const fetchLoginStatus = async () => {
-      try {
-        const response = await axios.get("/oauth2/siginup");
-        setEmail(response.data.email);
-
-        console.log("oauth2 이메일 조회 성공! ", response.data);
-      } catch (error) {
-        console.error("oauth2 이메일 조회 실패", error);
-      }
-    };
-
-    fetchLoginStatus();
-  }, [router]);
 
   return (
     <div className="flex flex-col items-center justify-start bg-bg-06 pb-80">
       <h1 className="flex h-120 items-center text-32 font-extrabold text-text-01 tablet:h-100 tablet:text-24">
-        회원 추가 정보
+        회원 정보 추가 입력
       </h1>
-      <SocialSignUpForm oauth2Email={email} />
+      <SocialSignUpForm />
     </div>
   );
 }

--- a/pages/oauth2/signup/index.tsx
+++ b/pages/oauth2/signup/index.tsx
@@ -1,17 +1,18 @@
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import SocialSignUpForm from "@/components/form/socialSignupForm";
 import axios from "@/lib/api/axios";
 
 export default function Oauth2Signup() {
   const router = useRouter();
+  const [email, setEmail] = useState("");
 
   useEffect(() => {
     const fetchLoginStatus = async () => {
       try {
         const response = await axios.get("/oauth2/siginup");
-        const oauth2Email = response.data.email;
+        setEmail(response.data.email);
 
         console.log("oauth2 이메일 조회 성공! ", response.data);
       } catch (error) {
@@ -27,7 +28,7 @@ export default function Oauth2Signup() {
       <h1 className="flex h-120 items-center text-32 font-extrabold text-text-01 tablet:h-100 tablet:text-24">
         회원 추가 정보
       </h1>
-      <SocialSignUpForm />
+      <SocialSignUpForm oauth2Email={email} />
     </div>
   );
 }


### PR DESCRIPTION
# 왜 필요한가요?

- 소셜 로그인

# 어떤 변화가 생겼나요?

### 소셜 로그인 과정
카카오 or 구글 로그인 버튼 클릭 -> 로그인 정보 입력 ->

1. 신규 유저는 oauth2/signup으로 이동하고 추가 정보 입력 -> 이때 소셜 이메일은 이메일로 받음. -> 가입 후 다시 로그인 페이지로 이동. -> 2번 수행.
2. 기본 유저는 oauth2/login으로 이동 ->  비동기처리로 액세스 토큰만 저장하고 홈으로 바로 이동.

# 개선 사항
- 위에서 신규 유저는 소셜 로그인을 두 번 해야한다. (회원가입 + 로그인)
- oauth2/login은 빠르게 지나가지만 유저의 환경 안 좋다면 해당 페이지가 보임.
- 아직 백엔드 처리 안 끝나서 현재 시점으로는 진행 불가.

# 스크린샷(optional)

### 회원 정보 추가 입력 (원래 카카오나 구글 이메일이 보이지만, 권한 아직 못 받음)
<img width="1134" alt="image" src="https://github.com/GilDongMu/gildongmu/assets/65000254/70122fc1-2c13-4a95-b558-fb28cc0d6f3e">


